### PR TITLE
Feature: handle sick leaves

### DIFF
--- a/odoohelper/odoohelper.py
+++ b/odoohelper/odoohelper.py
@@ -128,7 +128,8 @@ def attendance(password, user, period, start=None, end=None):
     leaves = client.read('hr.holidays', leave_ids)
 
     def daterange(start_date, end_date):
-        for n in range(int((end_date - start_date).days)):
+        # Always emit at least one day
+        for n in range(int((end_date - start_date).days) + 1):
             yield start_date + timedelta(n)
 
     # Pre-process the weeks and days


### PR DESCRIPTION
Adds handling of sick leaves for attendance calculation.

Ignores any worked hours for the days with sick leave (handles situations where the leave starts in the middle of the work day).

Other changes:
- Fixes one day leaves which were previously broken as range does not emit on 0 as the start value.
- Refer to `notes` instead of `overtime_reason`